### PR TITLE
Point to `_site` output folder in deploy action

### DIFF
--- a/.github/workflows/render_and_deploy.yml
+++ b/.github/workflows/render_and_deploy.yml
@@ -47,7 +47,9 @@ jobs:
       #     cp -r img build/
 
       - name: Deploy
-        if: github.event_name == 'push' && github.ref_type == 'tag'
+        if: |
+          (github.event_name == 'push' && github.ref_type == 'tag') ||
+          (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: _site

--- a/.github/workflows/render_and_deploy.yml
+++ b/.github/workflows/render_and_deploy.yml
@@ -37,18 +37,18 @@ jobs:
         run: |
           quarto render index.qmd --to revealjs
 
-      - name: Move outputs to build folder
-        if: github.event_name == 'push' && github.ref_type == 'tag'
-        run: |
-          mkdir build
-          mv index.html build/
-          mv index_files build/
-          touch build/.nojekyll
-          cp -r img build/
+      # - name: Move outputs to build folder
+      #   if: github.event_name == 'push' && github.ref_type == 'tag'
+      #   run: |
+      #     mkdir build
+      #     mv index.html build/
+      #     mv index_files build/
+      #     touch build/.nojekyll
+      #     cp -r img build/
 
       - name: Deploy
         if: github.event_name == 'push' && github.ref_type == 'tag'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: build
+          folder: _site
   

--- a/.github/workflows/render_and_deploy.yml
+++ b/.github/workflows/render_and_deploy.yml
@@ -37,15 +37,6 @@ jobs:
         run: |
           quarto render index.qmd --to revealjs
 
-      # - name: Move outputs to build folder
-      #   if: github.event_name == 'push' && github.ref_type == 'tag'
-      #   run: |
-      #     mkdir build
-      #     mv index.html build/
-      #     mv index_files build/
-      #     touch build/.nojekyll
-      #     cp -r img build/
-
       - name: Deploy
         if: |
           (github.event_name == 'push' && github.ref_type == 'tag') ||


### PR DESCRIPTION
In deploy action:
- point to `_site` folder in last step
- allow manual dispatch from main